### PR TITLE
rails 3.1 fixes

### DIFF
--- a/lib/preference_fu.rb
+++ b/lib/preference_fu.rb
@@ -49,8 +49,8 @@ module PreferenceFu
   
   module InstanceMethods
     
-    def initialize_with_preferences(attributes = nil)
-      initialize_without_preferences(attributes)
+    def initialize_with_preferences(*args)
+      initialize_without_preferences(*args)
       prefs # use this to trigger update_permissions in Preferences
       yield self if block_given?
     end
@@ -138,7 +138,7 @@ module PreferenceFu
     private
     
       def update_permissions
-        instance.write_attribute(instance.preferences_column, self.to_i)
+        instance.update_attribute(instance.preferences_column, self.to_i)
       end
     
       def is_true(value)

--- a/test/preference_fu_test.rb
+++ b/test/preference_fu_test.rb
@@ -43,6 +43,13 @@ class PreferenceFuTest < Test::Unit::TestCase
     assert_equal 4, @person.prefs.size
   end
   
+  def test_creating_and_loading
+    Person.create
+    
+    @new_person = Person.find(:first)
+    assert_equal [true, false, false, false], @new_person.prefs.map { |k, v| v }
+  end
+
   def test_saving_and_loading
     @person.prefs[:change_theme] = true
     @person.save


### PR DESCRIPTION
There are two fixes here.

1) fix unit test errors: NoMethodError: private method `write_attribute' called for #<Person id: nil, name: nil, preferences: nil>

2) fix for create: ArgumentError: wrong number of arguments (2 for 1)
    /Volumes/Devel/preference_fu/lib/preference_fu.rb:52:in `initialize_with_preferences'
